### PR TITLE
feat: if there is only one model do not prompt user

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,143 @@
+use std::error::Error;
+use git2::Repository;
+
+pub mod providers;
+pub mod git_analysis;
+pub mod git;
+pub mod ui;
+pub mod modes;
+
+#[derive(Debug)]
+pub struct Config {
+    model: Box<dyn git_analysis::GitAnalyzer>,
+    repo_path: String,
+}
+
+#[derive(Debug)]
+pub struct FileAnalysis {
+    pub path: String,
+    pub explanation: String,
+}
+
+impl Config {
+    pub fn new(model: Box<dyn git_analysis::GitAnalyzer>, repo_path: Option<String>) -> Self {
+        Self { 
+            model,
+            repo_path: repo_path.unwrap_or_else(|| ".".to_string())
+        }
+    }
+
+    pub fn with_new_model(self, model: Box<dyn git_analysis::GitAnalyzer>) -> Self {
+        Self {
+            model,
+            repo_path: self.repo_path,
+        }
+    }
+
+    pub fn with_new_repo(self, repo_path: String) -> Self {
+        Self {
+            model: self.model,
+            repo_path,
+        }
+    }
+
+    pub async fn generate_commit_message(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        self.model.generate_commit_message(diff).await
+    }
+
+    pub async fn analyze_changes(&self, repo: &Repository) -> Result<Vec<FileAnalysis>, Box<dyn Error>> {
+        let file_diffs = git::get_file_diffs(repo)?;
+        
+        let analysis_futures: Vec<_> = file_diffs.into_iter().map(|(path, diff)| {
+            let model = &self.model;
+            async move {
+                let explanation = model.analyze_file_changes(&diff).await?;
+                Ok::<FileAnalysis, Box<dyn Error>>(FileAnalysis {
+                    path,
+                    explanation,
+                })
+            }
+        }).collect();
+
+        futures::future::join_all(analysis_futures)
+            .await
+            .into_iter()
+            .collect()
+    }
+
+    pub async fn analyze_contributor(&self, stats: &str) -> Result<String, Box<dyn Error>> {
+        self.model.analyze_contributor(stats).await
+    }
+}
+
+pub async fn run(_repo_path: Option<String>) -> Result<(), Box<dyn Error>> {
+    let repo_path = loop {
+        let path = ui::get_repository_path(".")?;
+        match Repository::open(&path) {
+            Ok(_) => break path,
+            Err(_) => println!("Invalid git repository path. Please try again."),
+        }
+    };
+
+    let mut config = {
+        let providers = providers::get_available_providers();
+        let selected_idx = providers::select_provider(&providers)?;
+        if providers.len() == 1 {
+            println!("Using {} as the only available AI model", providers[0].name());
+        }
+        Config::new(git_analysis::wrap_provider(providers.into_iter().nth(selected_idx).unwrap()), Some(repo_path))
+    };
+    
+    let mut repo = Repository::open(&config.repo_path)?;
+
+    loop {
+        let mode = ui::select_mode().await?;
+        mode.execute(&config, &repo).await?;
+
+        // Determine available options based on number of providers
+        let providers = providers::get_available_providers();
+        let options = if providers.len() > 1 {
+            vec!["✨ Do something else", "🤖 Switch AI model", "📁 Switch repository", "❌ Exit"]
+        } else {
+            vec!["✨ Do something else", "📁 Switch repository", "❌ Exit"]
+        };
+
+        match ui::show_selection_menu("What would you like to do next?", &options, 0)? {
+            0 => (),  // Continue loop
+            1 if providers.len() > 1 => {
+                let selected_idx = providers::select_provider(&providers)?;
+                config = config.with_new_model(git_analysis::wrap_provider(providers.into_iter().nth(selected_idx).unwrap()));
+            }
+            1 => { // Repository switch when only one provider
+                let new_path = loop {
+                    let path = ui::get_repository_path(".")?;
+                    match Repository::open(&path) {
+                        Ok(new_repo) => {
+                            repo = new_repo;
+                            break path;
+                        }
+                        Err(_) => println!("Invalid git repository path. Please try again."),
+                    }
+                };
+                config = config.with_new_repo(new_path);
+            }
+            2 if providers.len() > 1 => { // Repository switch when multiple providers
+                let new_path = loop {
+                    let path = ui::get_repository_path(".")?;
+                    match Repository::open(&path) {
+                        Ok(new_repo) => {
+                            repo = new_repo;
+                            break path;
+                        }
+                        Err(_) => println!("Invalid git repository path. Please try again."),
+                    }
+                };
+                config = config.with_new_repo(new_path);
+            }
+            _ => break,
+        }
+        println!("\x1B[2J\x1B[1;1H"); // Clear screen
+    }
+    
+    Ok(())
+} 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -85,6 +85,11 @@ pub fn select_provider(providers: &[Box<dyn Provider>]) -> Result<usize, Box<dyn
         return Err(Box::new(ProviderError::NoProvidersAvailable));
     }
 
+    // If there's only one provider, automatically select it
+    if providers.len() == 1 {
+        return Ok(0);
+    }
+
     let provider_names: Vec<String> = providers
         .iter()
         .map(|p| p.name().to_string())


### PR DESCRIPTION
If the user has only added one valid key in `.env`, automatically select that model for all tasks and disable the model switching command.